### PR TITLE
Add Simulation Rate

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -2,6 +2,7 @@ module.exports = {
   GRAVITY: -9.8,
   MAX_INTERVAL: 4 / 60,
   ITERATIONS: 10,
+  SIMULATION_RATE: 8.333, // 8.333ms / 120hz
   ACTIVATION_STATE: {
     ACTIVE_TAG: "active",
     ISLAND_SLEEPING: "islandSleeping",

--- a/src/ammo.worker.js
+++ b/src/ammo.worker.js
@@ -302,7 +302,7 @@ onmessage = async event => {
       world = new World(event.data.worldConfig || {});
       lastTick = performance.now();
       simulationRate = event.data.simulationRate === undefined ? CONSTANTS.SIMULATION_RATE : event.data.simulationRate;
-      self.setInterval(tick, simulationRate);
+      self.setTimeout(tick, simulationRate);
       postMessage({ type: MESSAGE_TYPES.READY });
     });
   } else if (event.data.type === MESSAGE_TYPES.TRANSFER_DATA) {

--- a/src/ammo.worker.js
+++ b/src/ammo.worker.js
@@ -41,6 +41,8 @@ const ptrToIndex = {};
 
 const messageQueue = [];
 
+let simulationRate;
+
 let stepDuration = 0;
 
 let freeIndex = 0;
@@ -152,6 +154,8 @@ const tick = () => {
 
     releaseBuffer();
   }
+
+  setTimeout(tick, simulationRate - stepDuration);
 };
 const initSharedArrayBuffer = (sharedArrayBuffer, maxBodies) => {
   /** BUFFER HEADER
@@ -297,7 +301,8 @@ onmessage = async event => {
 
       world = new World(event.data.worldConfig || {});
       lastTick = performance.now();
-      self.setInterval(tick, 0);
+      simulationRate = event.data.simulationRate === undefined ? CONSTANTS.SIMULATION_RATE : event.data.simulationRate;
+      self.setInterval(tick, simulationRate);
       postMessage({ type: MESSAGE_TYPES.READY });
     });
   } else if (event.data.type === MESSAGE_TYPES.TRANSFER_DATA) {


### PR DESCRIPTION
This PR adds a configurable `simulationRate` which determines approximately how fast the physics worker processes events and simulates the world. By default it is set to 8.333ms, which makes the physics system run at 120hz.

Prior to this, the physics system ran on the worker as fast as possible. Which gives you the greatest chance at processing the message from the main thread and sending back the result with the least frame delay. The downside to this is that the physics worker was chewing through CPU resources. This is most apparent in Firefox where a `setInterval(fn, 0)` will cause the CPU utilization to go over 100%.

Now we are using a nested `setInterval` where we queue the next physics tick when the last is finished. We take into account the `stepDuration` so we maintain as close to a 120hz physics simulation rate as possible.

The results look promising. In Hubs, Firefox went from 168% CPU utilization to hovering around 28%. When running in the background it drops even lower. I would expect similar results in Firefox Reality.