### PR TITLE
Report collisions to both sets of objects involved

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -81,22 +81,22 @@ World.prototype.step = function(deltaTime) {
   const numManifolds = this.dispatcher.getNumManifolds();
   for (let i = 0; i < numManifolds; i++) {
     const persistentManifold = this.dispatcher.getManifoldByIndexInternal(i);
-    const numContacts = persistentManifold.getNumContacts();
     const body0ptr = Ammo.getPointer(persistentManifold.getBody0());
     const body1ptr = Ammo.getPointer(persistentManifold.getBody1());
-
-    for (let j = 0; j < numContacts; j++) {
-      const manifoldPoint = persistentManifold.getContactPoint(j);
-      const distance = manifoldPoint.getDistance();
-      if (distance <= this.epsilon) {
-        if (!this.collisions.has(body0ptr)) {
-          this.collisions.set(body0ptr, []);
-          this.collisionKeys.push(body0ptr);
-        }
-        if (this.collisions.get(body0ptr).indexOf(body1ptr) === -1) {
-          this.collisions.get(body0ptr).push(body1ptr);
-        }
-        break;
+    if(persistentManifold.getNumContacts()) {
+      if (!this.collisions.has(body0ptr)) {
+        this.collisions.set(body0ptr, []);
+        this.collisionKeys.push(body0ptr);
+      }
+      if (!this.collisions.has(body1ptr)) {
+        this.collisions.set(body1ptr, []);
+        this.collisionKeys.push(body1ptr);
+      }
+      if (this.collisions.get(body0ptr).indexOf(body1ptr) === -1) {
+        this.collisions.get(body0ptr).push(body1ptr);
+      }
+      if (this.collisions.get(body1ptr).indexOf(body0ptr) === -1) {
+        this.collisions.get(body1ptr).push(body0ptr);
       }
     }
   }

--- a/src/world.js
+++ b/src/world.js
@@ -59,8 +59,9 @@ World.prototype.removeBody = function(body) {
   const bodyptr = Ammo.getPointer(body);
   this.object3Ds.delete(bodyptr);
   this.collisions.delete(bodyptr);
-  if (this.collisionKeys.indexOf(bodyptr) !== -1) {
-    this.collisionKeys.splice(this.collisionKeys.indexOf(bodyptr), 1);
+  const idx = this.collisionKeys.indexOf(bodyptr);
+  if (idx !== -1) {
+    this.collisionKeys.splice(idx, 1);
   }
 };
 

--- a/src/world.js
+++ b/src/world.js
@@ -82,22 +82,29 @@ World.prototype.step = function(deltaTime) {
   const numManifolds = this.dispatcher.getNumManifolds();
   for (let i = 0; i < numManifolds; i++) {
     const persistentManifold = this.dispatcher.getManifoldByIndexInternal(i);
+    const numContacts = persistentManifold.getNumContacts();
     const body0ptr = Ammo.getPointer(persistentManifold.getBody0());
     const body1ptr = Ammo.getPointer(persistentManifold.getBody1());
-    if(persistentManifold.getNumContacts()) {
-      if (!this.collisions.has(body0ptr)) {
-        this.collisions.set(body0ptr, []);
-        this.collisionKeys.push(body0ptr);
-      }
-      if (!this.collisions.has(body1ptr)) {
-        this.collisions.set(body1ptr, []);
-        this.collisionKeys.push(body1ptr);
-      }
-      if (this.collisions.get(body0ptr).indexOf(body1ptr) === -1) {
-        this.collisions.get(body0ptr).push(body1ptr);
-      }
-      if (this.collisions.get(body1ptr).indexOf(body0ptr) === -1) {
-        this.collisions.get(body1ptr).push(body0ptr);
+
+    for (let j = 0; j < numContacts; j++) {
+      const manifoldPoint = persistentManifold.getContactPoint(j);
+      const distance = manifoldPoint.getDistance();
+      if (distance <= this.epsilon) {
+        if (!this.collisions.has(body0ptr)) {
+          this.collisions.set(body0ptr, []);
+          this.collisionKeys.push(body0ptr);
+        }
+        if (this.collisions.get(body0ptr).indexOf(body1ptr) === -1) {
+          this.collisions.get(body0ptr).push(body1ptr);
+        }
+        if (!this.collisions.has(body1ptr)) {
+          this.collisions.set(body1ptr, []);
+          this.collisionKeys.push(body1ptr);
+        }
+        if (this.collisions.get(body1ptr).indexOf(body0ptr) === -1) {
+          this.collisions.get(body1ptr).push(body0ptr);
+        }
+        break;
       }
     }
   }


### PR DESCRIPTION
Previously we were only reporting collisions for the first object in a collision pair. This results in world insertion order effecting which objects are told about collisions (was quite hard to trace this down). Both objects should report the collision, regardless of which happened to be the first in the collision pair.

~~Also, since we are not actually concerned with the nature of collision and just care if one occurred at all, it seems sufficient to check only for the existence of collision points rather than iterating them and checking distance. We can't simply check for manifolds existing, as they exist when objects are just "colliding" the broad phase.~~. Still unclear if this is true so restoring the checking of points.

In looking into this there seem to be some more optimized ways (`btGhostObject`) we might handle "trigger" type objects which we only want collision information on but no collision response, but would be more work to implement and more research to know if its even worth it. 