### PR TITLE
Update order of events in worker tick

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "three-ammo",
-  "version": "1.0.1",
+  "version": "1.0.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/ammo.worker.js
+++ b/src/ammo.worker.js
@@ -75,12 +75,6 @@ const tick = () => {
   setTimeout(tick, simulationRate);
 
   if (isBufferConsumed()) {
-    const now = performance.now();
-    const dt = now - lastTick;
-    world.step(dt / 1000);
-    stepDuration = performance.now() - now;
-    lastTick = now;
-
     while (messageQueue.length > 0) {
       const message = messageQueue.shift();
       switch (message.type) {
@@ -106,6 +100,12 @@ const tick = () => {
           activateBody(message);
       }
     }
+
+    const now = performance.now();
+    const dt = now - lastTick;
+    world.step(dt / 1000);
+    stepDuration = performance.now() - now;
+    lastTick = now;
 
     /** Buffer Schema
      * Every physics body has 26 * 4 bytes (64bit float/int) assigned in the buffer

--- a/src/body.js
+++ b/src/body.js
@@ -71,7 +71,6 @@ function Body(bodyConfig, matrix, world) {
       ? bodyConfig.activationState
       : ACTIVATION_STATE.ACTIVE_TAG;
   this.type = bodyConfig.type ? bodyConfig.type : TYPE.DYNAMIC;
-  this.emitCollisionEvents = bodyConfig.hasOwnProperty("emitCollisionEvents") ? bodyConfig.emitCollisionEvents : false;
   this.disableCollision = bodyConfig.hasOwnProperty("disableCollision") ? bodyConfig.disableCollision : false;
   this.collisionFilterGroup = bodyConfig.hasOwnProperty("collisionFilterGroup") ? bodyConfig.collisionFilterGroup : 1; //32-bit mask
   this.collisionFilterMask = bodyConfig.hasOwnProperty("collisionFilterMask") ? bodyConfig.collisionFilterMask : 1; //32-bit mask
@@ -138,10 +137,6 @@ Body.prototype._initBody = (function() {
     this.updateCollisionFlags();
 
     this.world.addBody(this.physicsBody, this.matrix, this.collisionFilterGroup, this.collisionFilterMask);
-
-    if (this.emitCollisionEvents) {
-      this.world.addEventListener(this.physicsBody);
-    }
   };
 })();
 

--- a/src/body.js
+++ b/src/body.js
@@ -47,7 +47,6 @@ function almostEqualsQuaternion(epsilon, u, v) {
  * parsing the elements geometry.
  */
 function Body(bodyConfig, matrix, world) {
-  this.loadedEvent = bodyConfig.loadedEvent ? bodyConfig.loadedEvent : "";
   this.mass = bodyConfig.hasOwnProperty("mass") ? bodyConfig.mass : 1;
   const worldGravity = world.physicsWorld.getGravity();
   this.gravity = new Ammo.btVector3(worldGravity.x(), worldGravity.y(), worldGravity.z());


### PR DESCRIPTION
Process the messageQueue first, then step the world. 

Also some minor cleanup of dead code. 
`emitCollisionEvents` and `loadedEvent` should be removed from https://github.com/mozilla/hubs/blob/master/src/components/body-helper.js